### PR TITLE
Adding method to modally present UINavigationController

### DIFF
--- a/Code/KIFSystemTestActor+ViewControllerActions.h
+++ b/Code/KIFSystemTestActor+ViewControllerActions.h
@@ -83,4 +83,14 @@
  */
 - (void)presentModalViewControllerWithIdentifier:(NSString *)controllerIdentifier fromStoryboardWithName:(NSString *)storyboardName configurationBlock:(void (^)(UIViewController *viewController))configurationBlock;
 
+
+/*!
+ @abstract Modally presents a given navigation controller on top of the currently presented view controller
+ @param navigationController The `UINavigationController` object you wish to present
+ @param configurationBlock An optional configuration block which is invoked with the navigation controller
+ before it is presented.
+ @result A configured test step.
+ */
+- (void)presentModalViewController:(UINavigationController *)navigationController configurationBlock:(void (^)(UINavigationController *navigationController))configurationBlock;
+
 @end

--- a/Code/KIFSystemTestActor+ViewControllerActions.m
+++ b/Code/KIFSystemTestActor+ViewControllerActions.m
@@ -101,4 +101,17 @@ static Class defaultToolbarClass;
     }];
 }
 
+- (void)presentModalViewController:(UINavigationController *)navigationController configurationBlock:(void (^)(UINavigationController *navigationController))configurationBlock
+{
+    [self runBlock:^KIFTestStepResult(NSError **error) {
+        UINavigationController *navigationControllerToPresent = navigationController;
+        KIFTestCondition(navigationControllerToPresent != nil, error, @"Expected a navigationController, but got nil");
+        
+        if (configurationBlock) configurationBlock(navigationControllerToPresent);
+        [[UIApplication sharedApplication].keyWindow.rootViewController.presentedViewController presentViewController:navigationControllerToPresent animated:true completion:nil]
+        
+        return KIFTestStepResultSuccess;
+    }];
+}
+
 @end


### PR DESCRIPTION
I added a method that allows you to modally present a pre-configured UINavigation controller. This is necessary for NavigationController subclasses that have custom initializers. 
