### PR TITLE
Feature/add framework deps

### DIFF
--- a/KIFViewControllerActions.podspec
+++ b/KIFViewControllerActions.podspec
@@ -13,5 +13,4 @@ Pod::Spec.new do |s|
   s.source_files = 'Code/*.{h,m}'
 
   s.dependency 'KIF', '>= 2.0.0'
-
 end

--- a/KIFViewControllerActions.podspec
+++ b/KIFViewControllerActions.podspec
@@ -8,9 +8,10 @@ Pod::Spec.new do |s|
 
   s.platform     = :ios, '5.0'
   s.requires_arc = true
-  
+  s.frameworks  = 'XCTest'
   s.source       = { :git => "https://github.com/blakewatters/KIFViewControllerActions.git", :tag => s.version.to_s }
   s.source_files = 'Code/*.{h,m}'
 
   s.dependency 'KIF', '>= 2.0.0'
+
 end


### PR DESCRIPTION
* Pull request adds the `XCTest` framework as en explicit dependency to the Podspec. This is required when installing pods using the `use_frameworks!` flag. 

See CP issue for details. https://github.com/CocoaPods/CocoaPods/issues/4141