### PR TITLE
xcode 8 support

### DIFF
--- a/Code/KIFSystemTestActor+ViewControllerActions.m
+++ b/Code/KIFSystemTestActor+ViewControllerActions.m
@@ -52,7 +52,7 @@ static Class defaultToolbarClass;
                     configurationBlock:(void (^)(id viewController))configurationBlock;
 {
     [self runBlock:^KIFTestStepResult(NSError **error) {
-        UIViewController *viewControllerToPresent = [viewControllerClass new];
+        UIViewController *viewControllerToPresent = [[viewControllerClass alloc] initWithNibName:nil bundle:nil];
         KIFTestCondition(viewControllerToPresent != nil, error, @"Expected a view controller, but got nil");
 
         Class navigationBarClassToUse = navigationBarClass ?: self.defaultNavigationBarClass;

--- a/KIFViewControllerActions.podspec
+++ b/KIFViewControllerActions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "KIFViewControllerActions"
-  s.version      = "1.0.1"
+  s.version      = "1.0.2"
   s.summary      = "Adds actions to KIF for presenting view controllers to aid in functional testing."
   s.homepage     = "https://github.com/blakewatters/KIFViewControllerActions"
   s.license      = { :type => 'Apache', :file => 'LICENSE'}


### PR DESCRIPTION
Fails build in xcode 8.2 due to using the unavailable `new` method on `UIViewController`

<img width="880" alt="screen shot 2016-12-30 at 11 07 01 am" src="https://cloud.githubusercontent.com/assets/3241469/21568165/37ea6f14-ce80-11e6-9bc3-a77f00f3ca5b.png">

fixes https://github.com/blakewatters/KIFViewControllerActions/issues/5

This should be merged instead of https://github.com/blakewatters/KIFViewControllerActions/pull/6, as that did not use the designated `UIViewController` initializer `initWithNibName:bundle:`
